### PR TITLE
Create badpackages.txt

### DIFF
--- a/modules/badpackages.txt
+++ b/modules/badpackages.txt
@@ -1,0 +1,9 @@
+netcat
+samba-libs:i386
+nmap
+john
+apache
+burp
+wireshark
+metasploit
+squid


### PR DESCRIPTION
List of commonly forbidden package names. should only include the package name that when purged, will remove all of the following dependencies for that package, if possible. ex. a 'samba' package doesnt exist, instead we purge samba-libs:i386 since it also removes its dependencies.  NOTE: I believe in the future we should move away from automating purges, and rather delete it while backing up the data to the tmp, incase the script accidently removes a situationally critical package